### PR TITLE
update to v5.1.3

### DIFF
--- a/com.github.vladimiry.ElectronMail.metainfo.xml
+++ b/com.github.vladimiry.ElectronMail.metainfo.xml
@@ -29,6 +29,7 @@
     <content_attribute id="social-info">intense</content_attribute>
   </content_rating>
   <releases>
+    <release version="5.1.3" date="2022-01-14"/>
     <release version="5.1.2" date="2022-10-28"/>
     <release version="5.1.1" date="2022-09-21"/>
     <release version="5.1.0" date="2022-08-27"/>

--- a/com.github.vladimiry.ElectronMail.yaml
+++ b/com.github.vladimiry.ElectronMail.yaml
@@ -23,6 +23,8 @@ finish-args:
   # required for notifications in various desktop environments
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
+  # TODO drop "--own-name=org.kde.*" workaround on https://github.com/flathub/flatpak-builder-lint/issues/66 resolving
+  - --own-name=org.kde.*
   # required for advanced input methods e.g. writing CJK languages
   - --talk-name=org.freedesktop.portal.Fcitx
   # gtk-cups-backend
@@ -32,6 +34,7 @@ finish-args:
 modules:
   - module-gtk-cups-backend.yml
   - module-gtk-settings.yaml
+  - module-libnotify.yaml
   - module-libsecret.yaml
   - module-squashfs.yaml
   - module-electron-mail.yaml

--- a/module-electron-mail.yaml
+++ b/module-electron-mail.yaml
@@ -12,8 +12,8 @@ build-commands:
 sources:
   - type: file
     dest-filename: electron-mail.deb
-    url: https://github.com/vladimiry/ElectronMail/releases/download/v5.1.2/electron-mail-5.1.2-linux-amd64.deb
-    sha256: 1901a591fb59c20182d1c40177a282b99ff6b4b16909528b39c67493dce5764f
+    url: https://github.com/vladimiry/ElectronMail/releases/download/v5.1.3/electron-mail-5.1.3-linux-amd64.deb
+    sha256: dadde04072a2da3d8b69cf9b16de85184bf3237439a9b6639937755bc2f4c425
   - type: script
     dest-filename: electron-mail-entrypoint.sh
     commands:

--- a/module-libnotify.yaml
+++ b/module-libnotify.yaml
@@ -1,0 +1,10 @@
+name: libnotify
+buildsystem: meson
+config-opts:
+  - -Dtests=false
+  - -Dman=false
+  - -Dgtk_doc=false
+sources:
+  - type: archive
+    url: https://gitlab.gnome.org/GNOME/libnotify/-/archive/0.8.1/libnotify-0.8.1.tar.bz2
+    sha256: 6a17cd1eacc17c2dd2620e68da2b25151f08489ca17210ae32ae4b8c16e46889


### PR DESCRIPTION
This release comes with [StatusNotifierItem](https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/)-based tray icon and I didn't figure yet how to make it work in flatpak container, so the merge is on pause.