### PR TITLE
Drop `org.kde.*` own-name

### DIFF
--- a/com.github.vladimiry.ElectronMail.yaml
+++ b/com.github.vladimiry.ElectronMail.yaml
@@ -23,8 +23,6 @@ finish-args:
   # required for notifications in various desktop environments
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
-  # TODO drop "--own-name=org.kde.*" workaround on https://github.com/flathub/flatpak-builder-lint/issues/66 resolving
-  - --own-name=org.kde.*
   # required for advanced input methods e.g. writing CJK languages
   - --talk-name=org.freedesktop.portal.Fcitx
   # gtk-cups-backend


### PR DESCRIPTION
This is no longer required with newer Electron and runtime

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement
> but known exceptions to this are Electron versions older than 23.3.0.

Current version uses Electron 26.2.1
https://github.com/vladimiry/ElectronMail/blob/8b54e6941c020adbf1a04b4063507bf724d0d059/package.json#L171