### PR TITLE
upgrade runtime from 23.08 to 24.08

### DIFF
--- a/com.github.vladimiry.ElectronMail.yaml
+++ b/com.github.vladimiry.ElectronMail.yaml
@@ -1,8 +1,8 @@
 app-id: com.github.vladimiry.ElectronMail
 base: org.electronjs.Electron2.BaseApp
-base-version: '23.08'
+base-version: '24.08'
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 separate-locales: false
 command: electron-mail


### PR DESCRIPTION
Updates the flatpak runtime from 23.08 to 24.08.

ElectronMail is the last of my flatpaks to use 23.08.

I have built ElectronMail locally with these changes and everything I have tested works fine.